### PR TITLE
changes in example code and compile.sh

### DIFF
--- a/examples/basic.c
+++ b/examples/basic.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <string.h>
 
 #include "pillowtalk.h"
 

--- a/examples/compile.sh
+++ b/examples/compile.sh
@@ -1,1 +1,1 @@
-gcc -lpillowtalk -o basic basic.c
+gcc basic.c -lpillowtalk -o basic


### PR DESCRIPTION
There was a problem with the gcc syntax in examples/compile.sh

A compiler warning regarding strings was fixed in examples/basic.c